### PR TITLE
Add tests to the output template project

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mamba
-expects
-testfixtures
-cookiecutter
+mamba==0.8.6
+expects==0.8.0
+testfixtures==4.10.0
+cookiecutter==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jinja2-time
+jinja2-time==0.1.0

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+install: 
+  - "pip install -r requirements-dev.txt"
+script: pytest

--- a/{{cookiecutter.project_slug}}/pytest.ini
+++ b/{{cookiecutter.project_slug}}/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests/

--- a/{{cookiecutter.project_slug}}/requirements-dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements-dev.txt
@@ -1,0 +1,4 @@
+cookiecutter==1.6.0
+flake8==3.5.0
+pytest==3.3.2
+pytest-cookies==0.3.0

--- a/{{cookiecutter.project_slug}}/tests/test_bake_project.py
+++ b/{{cookiecutter.project_slug}}/tests/test_bake_project.py
@@ -1,0 +1,30 @@
+from contextlib import contextmanager
+
+import os
+
+
+@contextmanager
+def inside_dir(dirpath):
+    """
+    Execute code from inside the given directory
+    :param dirpath: String, path of the directory the command is being run.
+    """
+    old_path = os.getcwd()
+    try:
+        os.chdir(dirpath)
+        yield
+    finally:
+        os.chdir(old_path)
+
+
+def test_project_tree(cookies):
+    result = cookies.bake(extra_context={'project_slug': 'test_project'})
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.project.basename == 'test_project'
+
+
+def test_run_flake8(cookies):
+    result = cookies.bake(extra_context={'project_slug': 'flake8_compat'})
+    with inside_dir(str(result.project)):
+        assert os.subprocess.check_call(['flake8']) == 0


### PR DESCRIPTION
Fixes #5 

When for the simplest options:
- Travis CI
- Pytest with cookie cutter plugin, testing basic output & flake8 compatibility
- requirements file for dependency management
