### PR TITLE
Pin the dependencies so that build doesn't break

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mamba
-expects
-testfixtures
-cookiecutter
+mamba==0.8.6
+expects==0.8.0
+testfixtures==4.10.0
+cookiecutter==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jinja2-time
+jinja2-time==0.1.0


### PR DESCRIPTION
While submitting 2 recent PRs, I realised the build was broken. Turns out the rest of the world has moved quite a bit since the last build, so pinning the dependencies should do for now.