### PR TITLE
Fix a test error in a fresh project.

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/test_bake_project.py
+++ b/{{cookiecutter.project_slug}}/tests/test_bake_project.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 import os
+import subprocess
 
 
 @contextmanager
@@ -27,4 +28,4 @@ def test_project_tree(cookies):
 def test_run_flake8(cookies):
     result = cookies.bake(extra_context={'project_slug': 'flake8_compat'})
     with inside_dir(str(result.project)):
-        assert os.subprocess.check_call(['flake8']) == 0
+        subprocess.check_call(['flake8'])


### PR DESCRIPTION
## Error

When a new project is generated, the pytest will always fail!

```python
cookies = <pytest_cookies.Cookies object at 0x7f723681c710>
    def test_run_flake8(cookies):
        result = cookies.bake(extra_context={'project_slug': 'flake8_compat'})
        with inside_dir(str(result.project)):
>           assert os.subprocess.check_call(['flake8']) == 0
E           AttributeError: module 'os' has no attribute 'subprocess'
tests/test_bake_project.py:30: AttributeError
```

An online error example: <https://travis-ci.org/yanqd0/cookiecutter-serious-pycli/builds/447092846>

## Solution

The [subprocess] has become an independent module for a long time.

By the way, the `check_call` will always return `0`, if it is not crashed. So I delete the unnecessary `assert`.

[subprocess]:https://docs.python.org/2.7/library/subprocess.html

## Test

I really don't know how to test this with Mamba, so the regression test is missing.